### PR TITLE
Notify consumer channels in the example and tests

### DIFF
--- a/example/Example.hs
+++ b/example/Example.hs
@@ -111,6 +111,7 @@ main = do
         runSQL_ $ "INSERT INTO consumers_example_jobs "
           <> "(run_at, finished_at, reserved_by, attempts, message) "
           <> "VALUES (NOW(), NULL, NULL, 0, 'hello')"
+        runSQL_ "SELECT pg_notify('consumers_example_chan', '')"
         commit
 
       -- Invoked when a job is ready to be processed.

--- a/example/Example.hs
+++ b/example/Example.hs
@@ -111,7 +111,7 @@ main = do
         runSQL_ $ "INSERT INTO consumers_example_jobs "
           <> "(run_at, finished_at, reserved_by, attempts, message) "
           <> "VALUES (NOW(), NULL, NULL, 0, 'hello')"
-        runSQL_ "SELECT pg_notify('consumers_example_chan', '')"
+        notify "consumers_example_chan" ""
         commit
 
       -- Invoked when a job is ready to be processed.

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -160,7 +160,7 @@ test = do
         runSQL_ $ "INSERT INTO consumers_test_jobs "
           <> "(run_at, finished_at, reserved_by, attempts, countdown) "
           <> "VALUES (" <?> now <> " + interval '1 hour', NULL, NULL, 0, " <?> countdown <> ")"
-        runSQL_ "SELECT pg_notify('consumers_test_chan', '')"
+        notify "consumers_test_chan" ""
 
       processJob :: (Int64, Int32) -> TestEnv Result
       processJob (_idx, countdown) = do

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -160,6 +160,7 @@ test = do
         runSQL_ $ "INSERT INTO consumers_test_jobs "
           <> "(run_at, finished_at, reserved_by, attempts, countdown) "
           <> "VALUES (" <?> now <> " + interval '1 hour', NULL, NULL, 0, " <?> countdown <> ")"
+        runSQL_ "SELECT pg_notify('consumers_test_chan', '')"
 
       processJob :: (Int64, Int32) -> TestEnv Result
       processJob (_idx, countdown) = do


### PR DESCRIPTION
I find it a bit misleading that a notification channel is set for the consumer in both the tests and the example but those channels are never notified when a new job is inserted, especially since these jobs should be processed right away as `run_at` is set for `now()` in both cases. 