### PR TITLE
[CORE-5803] Remove support for advisory locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# consumers-2.3.1.0 (2023-??-??)
+* Drop support for advisory locks
+
 # consumers-2.3.0.0 (2022-07-07)
 * Update to monad-time 0.4.0.0
 * Support for GHC 9.2

--- a/consumers.cabal
+++ b/consumers.cabal
@@ -1,5 +1,5 @@
 name:               consumers
-version:            2.3.0.0
+version:            2.3.1.0
 synopsis:           Concurrent PostgreSQL data consumers
 
 description:        Library for setting up concurrent consumers of data

--- a/consumers.cabal
+++ b/consumers.cabal
@@ -35,7 +35,7 @@ library
                   , containers        >= 0.5    && < 0.7
                   , exceptions        >= 0.10   && < 0.11
                   , extra             >= 1.6    && < 1.8
-                  , hpqtypes          >= 1.7    && < 2.0
+                  , hpqtypes          >= 1.11   && < 2.0
                   , lifted-base       >= 0.2    && < 0.3
                   , lifted-threads    >= 1.0    && < 1.1
                   , log-base          >= 0.11   && < 0.12


### PR DESCRIPTION
Remove support for advisory locks since we need to rely on the `skip locked` mechanism anyway when we implement deduplicating workers.