### PR TITLE
Reenqueue unparseable job

### DIFF
--- a/consumers-metrics-prometheus/src/Database/PostgreSQL/Consumers/Instrumented.hs
+++ b/consumers-metrics-prometheus/src/Database/PostgreSQL/Consumers/Instrumented.hs
@@ -122,8 +122,8 @@ registerConsumerMetrics ConsumerMetricsConfig {..} = liftBase $ do
       . Prom.vector "job_name"
       $ Prom.counter
         Prom.Info
-          { metricName = "consumers_job_parsing_failures",
-            metricHelp = "Number of jobs that failed to parse, by job_name"
+          { metricName = "consumers_job_parsing_failures"
+          , metricHelp = "Number of jobs that failed to parse, by job_name"
           }
   pure $ ConsumerMetrics {..}
 

--- a/consumers-metrics-prometheus/src/Database/PostgreSQL/Consumers/Instrumented.hs
+++ b/consumers-metrics-prometheus/src/Database/PostgreSQL/Consumers/Instrumented.hs
@@ -79,6 +79,7 @@ data ConsumerMetrics = ConsumerMetrics
   , jobsOverdue :: Prom.Vector Prom.Label1 Prom.Gauge
   , jobsReserved :: Prom.Vector Prom.Label1 Prom.Counter
   , jobsExecution :: Prom.Vector Prom.Label2 Prom.Histogram
+  , jobsParsingFailure :: Prom.Vector Prom.Label1 Prom.Counter
   }
 
 registerConsumerMetrics :: MonadBaseControl IO m => ConsumerMetricsConfig -> m ConsumerMetrics
@@ -116,6 +117,14 @@ registerConsumerMetrics ConsumerMetricsConfig {..} = liftBase $ do
           , metricHelp = "Execution time of jobs in seconds, by job_name, includes the job_result"
           }
         jobExecutionBuckets
+  jobsParsingFailure <-
+    Prom.register
+      . Prom.vector "job_name"
+      $ Prom.counter
+        Prom.Info
+          { metricName = "consumers_job_parsing_failures",
+            metricHelp = "Number of jobs that failed to parse, by job_name"
+          }
   pure $ ConsumerMetrics {..}
 
 -- | Run a 'ConsumerConfig', but with instrumentation added.
@@ -235,7 +244,7 @@ instrumentConsumerConfig
   -> ConsumerConfig m idx job
   -> ConsumerConfig m idx job
 instrumentConsumerConfig ConsumerMetrics {..} ConsumerConfig {..} =
-  ConsumerConfig {ccProcessJob = ccProcessJob', ..}
+  ConsumerConfig {ccProcessJob = ccProcessJob', ccOnFailedToFetchJob = ccOnFailedToFetchJob', ..}
   where
     jobName = unRawSQL ccJobsTable
 
@@ -263,3 +272,7 @@ instrumentConsumerConfig ConsumerMetrics {..} ConsumerConfig {..} =
       liftBase $ Prom.withLabel jobsExecution (jobName, resultLabel) (`Prom.observe` duration)
 
     handleEx e = logAttention "Exception while instrumenting job" $ object ["exception" .= show e]
+
+    ccOnFailedToFetchJob' errorTxt idx = do
+      liftBase $ Prom.withLabel jobsParsingFailure jobName Prom.incCounter
+      ccOnFailedToFetchJob errorTxt idx

--- a/consumers/CHANGELOG.md
+++ b/consumers/CHANGELOG.md
@@ -1,3 +1,6 @@
+# consumers-2.4.0.0 (TBD)
+* Add ability to reenqueue unfetchable jobs, let ccJobFetcher fail
+
 # consumers-2.3.4.0 (2025-11-27)
 * Compatibility with `hpqtypes` >= 1.13.0.0.
 

--- a/consumers/consumers.cabal
+++ b/consumers/consumers.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               consumers
-version:            2.3.4.0
+version:            2.4.0.0
 synopsis:           Concurrent PostgreSQL data consumers
 
 description:        Library for setting up concurrent consumers of data

--- a/consumers/example/Example.hs
+++ b/consumers/example/Example.hs
@@ -108,7 +108,7 @@ main = do
         , ccNotificationTimeout = 10 * 1000000 -- 10 sec
         , ccMaxRunningJobs = 1
         , ccProcessJob = processJob
-        , ccOnFailedToFetchJob = handleFailedToFetchJob
+        , ccOnFailedToFetchJob = shouldNotFail
         , ccOnException = handleException
         , ccJobLogData = \(i, _) -> ["job_id" .= i]
         }
@@ -135,11 +135,6 @@ main = do
     -- queue, mark it as processed, or schedule it for rerun.
     handleException :: SomeException -> (Int64, T.Text) -> AppM Action
     handleException _ _ = pure . RerunAfter $ imicroseconds 500000
-
-    handleFailedToFetchJob :: String -> Int64 -> AppM Action
-    handleFailedToFetchJob msg idx = do
-      logAttention "Failing to fetch job" $ object ["error" .= msg, "job_index" .= idx]
-      pure . RerunAfter $ idays 48
 
 -- | Table where jobs are stored. See
 -- 'Database.PostgreSQL.Consumers.Config.ConsumerConfig'.

--- a/consumers/example/Example.hs
+++ b/consumers/example/Example.hs
@@ -108,6 +108,7 @@ main = do
         , ccNotificationTimeout = 10 * 1000000 -- 10 sec
         , ccMaxRunningJobs = 1
         , ccProcessJob = processJob
+        , ccOnFailedToFetchJob = handleFailedToFetchJob 
         , ccOnException = handleException
         , ccJobLogData = \(i, _) -> ["job_id" .= i]
         }
@@ -134,6 +135,11 @@ main = do
     -- queue, mark it as processed, or schedule it for rerun.
     handleException :: SomeException -> (Int64, T.Text) -> AppM Action
     handleException _ _ = pure . RerunAfter $ imicroseconds 500000
+
+    handleFailedToFetchJob :: SomeException -> (Int64, T.Text) -> AppM (Either (Int64, Result) (Int64, T.Text))
+    handleFailedToFetchJob e (idx, _) = do
+      logAttention "Failing to fetch job" $ object ["error" .= show e]
+      pure . Left $ (idx, Failed . RerunAfter $ idays 48)
 
 -- | Table where jobs are stored. See
 -- 'Database.PostgreSQL.Consumers.Config.ConsumerConfig'.

--- a/consumers/example/Example.hs
+++ b/consumers/example/Example.hs
@@ -108,7 +108,7 @@ main = do
         , ccNotificationTimeout = 10 * 1000000 -- 10 sec
         , ccMaxRunningJobs = 1
         , ccProcessJob = processJob
-        , ccOnFailedToFetchJob = shouldNotFail
+        , ccOnFailedToFetchJob = defaultOnFailedToFetchJob
         , ccOnException = handleException
         , ccJobLogData = \(i, _) -> ["job_id" .= i]
         }

--- a/consumers/example/Example.hs
+++ b/consumers/example/Example.hs
@@ -102,13 +102,13 @@ main = do
         { ccJobsTable = "consumers_example_jobs"
         , ccConsumersTable = "consumers_example_consumers"
         , ccJobSelectors = ["id", "message"]
-        , ccJobFetcher = id
+        , ccJobFetcher = Right
         , ccJobIndex = \(i :: Int64, _msg :: T.Text) -> i
         , ccNotificationChannel = Just "consumers_example_chan"
         , ccNotificationTimeout = 10 * 1000000 -- 10 sec
         , ccMaxRunningJobs = 1
         , ccProcessJob = processJob
-        , ccOnFailedToFetchJob = handleFailedToFetchJob 
+        , ccOnFailedToFetchJob = handleFailedToFetchJob
         , ccOnException = handleException
         , ccJobLogData = \(i, _) -> ["job_id" .= i]
         }
@@ -136,10 +136,10 @@ main = do
     handleException :: SomeException -> (Int64, T.Text) -> AppM Action
     handleException _ _ = pure . RerunAfter $ imicroseconds 500000
 
-    handleFailedToFetchJob :: SomeException -> (Int64, T.Text) -> AppM (Either (Int64, Result) (Int64, T.Text))
-    handleFailedToFetchJob e (idx, _) = do
-      logAttention "Failing to fetch job" $ object ["error" .= show e]
-      pure . Left $ (idx, Failed . RerunAfter $ idays 48)
+    handleFailedToFetchJob :: String -> Int64 -> AppM Action
+    handleFailedToFetchJob msg idx = do
+      logAttention "Failing to fetch job" $ object ["error" .= msg, "job_index" .= idx]
+      pure . RerunAfter $ idays 48
 
 -- | Table where jobs are stored. See
 -- 'Database.PostgreSQL.Consumers.Config.ConsumerConfig'.

--- a/consumers/src/Database/PostgreSQL/Consumers/Components.hs
+++ b/consumers/src/Database/PostgreSQL/Consumers/Components.hs
@@ -18,6 +18,7 @@ import Control.Monad.Catch
 import Control.Monad.Time
 import Control.Monad.Trans
 import Control.Monad.Trans.Control
+import Data.Either
 import Data.Foldable qualified as F
 import Data.Function
 import Data.Int
@@ -28,7 +29,6 @@ import Database.PostgreSQL.Consumers.Consumer
 import Database.PostgreSQL.Consumers.Utils
 import Database.PostgreSQL.PQTypes
 import Log
-import Data.Either (partitionEithers)
 
 -- | Run the consumer. The purpose of the returned monadic action is to wait for
 -- currently processed jobs and clean up. This function is best used in
@@ -269,7 +269,7 @@ spawnMonitor ConsumerConfig {..} cs cid = forkP "monitor" . forever $ do
             , "WHERE reserved_by = ANY(" <?> Array1 inactive <+> ")"
             , "FOR UPDATE SKIP LOCKED"
             ]
-        stuckJobs <- fetchMany ccJobFetcher
+        stuckJobs <- rights <$> fetchMany ccJobFetcher
         unless (null stuckJobs) $ do
           results <- forM stuckJobs $ \job -> do
             action <- lift $ ccOnException (toException ThreadKilled) job
@@ -349,7 +349,7 @@ spawnDispatcher ConsumerConfig {..} cs cid semaphore runningJobsInfo runningJobs
             . restore
             $ do
               mapM startJob succeededJobs >>= mapM joinJob >>= updateJobs
-              mapM (\failedRow -> sequence (ccRowIndex failedRow, ccOnFailedToFetchJob failedRow)) failedJobs >>= updateJobs
+              mapM (\(idx, string) -> sequence (idx, Failed <$> ccOnFailedToFetchJob string idx)) failedJobs >>= updateJobs
 
         when (batchSize == limit) $ do
           maxBatchSize <- atomically $ do
@@ -360,7 +360,7 @@ spawnDispatcher ConsumerConfig {..} cs cid semaphore runningJobsInfo runningJobs
 
       pure (batchSize > 0)
 
-    reserveJobs :: (MonadCatch m) => Int -> m ([Either row job], Int)
+    reserveJobs :: MonadCatch m => Int -> m ([Either (idx, String) job], Int)
     reserveJobs limit = runDBT cs ts $ do
       now <- currentTime
       n <-
@@ -375,11 +375,7 @@ spawnDispatcher ConsumerConfig {..} cs cid semaphore runningJobsInfo runningJobs
             , "WHERE id IN (" <> reservedJobs now <> ")"
             , "RETURNING" <+> mintercalate ", " ccJobSelectors
             ]
-      let tryAndParse row = ES.handle
-            (\(SomeException _) -> pure $ Left row)
-            (fmap Right . liftBase . evaluate $ ccJobFetcher row)
-      _ {- ([row], [job]) -} <- fmap partitionEithers . traverse tryAndParse . F.toList =<< queryResult
-      undefined
+      (,n) . F.toList . fmap ccJobFetcher <$> queryResult
       where
         reservedJobs :: UTCTime -> SQL
         reservedJobs now =

--- a/consumers/src/Database/PostgreSQL/Consumers/Components.hs
+++ b/consumers/src/Database/PostgreSQL/Consumers/Components.hs
@@ -10,7 +10,7 @@ import Control.Concurrent.Lifted
 import Control.Concurrent.STM hiding (atomically)
 import Control.Concurrent.STM qualified as STM
 import Control.Concurrent.Thread.Lifted qualified as T
-import Control.Exception (AsyncException (ThreadKilled), evaluate)
+import Control.Exception (AsyncException (ThreadKilled))
 import Control.Exception.Safe qualified as ES
 import Control.Monad
 import Control.Monad.Base

--- a/consumers/src/Database/PostgreSQL/Consumers/Components.hs
+++ b/consumers/src/Database/PostgreSQL/Consumers/Components.hs
@@ -154,6 +154,15 @@ runConsumerWithMaybeIdleSignal cc0 cs mIdleSignal
                   , "action" .= show action
                   ]
               pure action
+        , ccOnFailedToFetchJob = \t i ->
+            ccOnFailedToFetchJob cc0 t i `ES.catchAny` \handlerEx -> do
+              let action = RerunAfter $ idays 1
+              logAttention "ccOnFailedToFetchJob threw an exception" $
+                object
+                  [ "exception" .= show handlerEx
+                  , "action" .= show action
+                  ]
+              pure action
         }
 
     waitForRunningJobs runningJobsInfo runningJobs = do
@@ -381,7 +390,7 @@ spawnDispatcher ConsumerConfig {..} cs cid semaphore runningJobsInfo runningJobs
             , "WHERE id IN (" <> reservedJobs now <> ")"
             , "RETURNING" <+> mintercalate ", " ccJobSelectors
             ]
-      -- Decode lazily as we want the transaction to be as short as possible
+      -- Decode lazily as we want the transaction to be as short as possible.
       (,n) . F.toList . fmap ccJobFetcher <$> queryResult
       where
         reservedJobs :: UTCTime -> SQL

--- a/consumers/src/Database/PostgreSQL/Consumers/Components.hs
+++ b/consumers/src/Database/PostgreSQL/Consumers/Components.hs
@@ -273,11 +273,12 @@ spawnMonitor ConsumerConfig {..} cs cid = forkP "monitor" . forever $ do
         stuckJobs <- fetchMany ccJobFetcher
         unless (null stuckJobs) $ do
           results <- forM stuckJobs $ \job -> do
-            action <- lift $ 
-              either 
-                (\(idx, t) -> ccOnFailedToFetchJob t idx) 
-                (ccOnException (toException ThreadKilled))
-                job
+            action <-
+              lift $
+                either
+                  (\(idx, t) -> ccOnFailedToFetchJob t idx)
+                  (ccOnException (toException ThreadKilled))
+                  job
             pure (either fst ccJobIndex job, Failed action)
           runSQL_ $ updateJobsQuery ccJobsTable results now
         runPreparedSQL_ (preparedSqlName "removeInactive" ccConsumersTable) $

--- a/consumers/src/Database/PostgreSQL/Consumers/Components.hs
+++ b/consumers/src/Database/PostgreSQL/Consumers/Components.hs
@@ -28,6 +28,7 @@ import Database.PostgreSQL.Consumers.Consumer
 import Database.PostgreSQL.Consumers.Utils
 import Database.PostgreSQL.PQTypes
 import Log
+import Data.Either (partitionEithers)
 
 -- | Run the consumer. The purpose of the returned monadic action is to wait for
 -- currently processed jobs and clean up. This function is best used in
@@ -328,6 +329,7 @@ spawnDispatcher ConsumerConfig {..} cs cid semaphore runningJobsInfo runningJobs
     loop :: Int -> m Bool
     loop limit = do
       (batch, batchSize) <- reserveJobs limit
+      let (failedJobs, succeededJobs) = partitionEithers batch
       when (batchSize > 0) $ do
         logInfo "Processing batch" $
           object
@@ -346,7 +348,8 @@ spawnDispatcher ConsumerConfig {..} cs cid semaphore runningJobsInfo runningJobs
             . (`finally` subtractJobs)
             . restore
             $ do
-              mapM startJob batch >>= mapM joinJob >>= updateJobs
+              mapM startJob succeededJobs >>= mapM joinJob >>= updateJobs
+              mapM (\failedRow -> sequence (ccRowIndex failedRow, ccOnFailedToFetchJob failedRow)) failedJobs >>= updateJobs
 
         when (batchSize == limit) $ do
           maxBatchSize <- atomically $ do
@@ -357,7 +360,7 @@ spawnDispatcher ConsumerConfig {..} cs cid semaphore runningJobsInfo runningJobs
 
       pure (batchSize > 0)
 
-    reserveJobs :: Int -> m ([job], Int)
+    reserveJobs :: (MonadCatch m) => Int -> m ([Either row job], Int)
     reserveJobs limit = runDBT cs ts $ do
       now <- currentTime
       n <-
@@ -372,8 +375,9 @@ spawnDispatcher ConsumerConfig {..} cs cid semaphore runningJobsInfo runningJobs
             , "WHERE id IN (" <> reservedJobs now <> ")"
             , "RETURNING" <+> mintercalate ", " ccJobSelectors
             ]
-      -- Decode lazily as we want the transaction to be as short as possible.
-      (,n) . F.toList . fmap ccJobFetcher <$> queryResult
+      let tryAndParse :: (row -> job) -> row -> Either row job
+          tryAndParse p row = ES.handle (\(SomeException _) -> Left row) (Right $ p row)
+      (,n) . F.toList . fmap (tryAndParse ccJobFetcher) <$> queryResult
       where
         reservedJobs :: UTCTime -> SQL
         reservedJobs now =

--- a/consumers/src/Database/PostgreSQL/Consumers/Components.hs
+++ b/consumers/src/Database/PostgreSQL/Consumers/Components.hs
@@ -24,6 +24,7 @@ import Data.Function
 import Data.Int
 import Data.Map.Strict qualified as M
 import Data.Monoid.Utils
+import Data.Text qualified as T
 import Database.PostgreSQL.Consumers.Config
 import Database.PostgreSQL.Consumers.Consumer
 import Database.PostgreSQL.Consumers.Utils
@@ -349,7 +350,7 @@ spawnDispatcher ConsumerConfig {..} cs cid semaphore runningJobsInfo runningJobs
             . restore
             $ do
               mapM startJob succeededJobs >>= mapM joinJob >>= updateJobs
-              mapM (\(idx, string) -> sequence (idx, Failed <$> ccOnFailedToFetchJob string idx)) failedJobs >>= updateJobs
+              mapM (\(idx, txt) -> sequence (idx, Failed <$> ccOnFailedToFetchJob txt idx)) failedJobs >>= updateJobs
 
         when (batchSize == limit) $ do
           maxBatchSize <- atomically $ do
@@ -360,7 +361,7 @@ spawnDispatcher ConsumerConfig {..} cs cid semaphore runningJobsInfo runningJobs
 
       pure (batchSize > 0)
 
-    reserveJobs :: MonadCatch m => Int -> m ([Either (idx, String) job], Int)
+    reserveJobs :: MonadCatch m => Int -> m ([Either (idx, T.Text) job], Int)
     reserveJobs limit = runDBT cs ts $ do
       now <- currentTime
       n <-

--- a/consumers/src/Database/PostgreSQL/Consumers/Components.hs
+++ b/consumers/src/Database/PostgreSQL/Consumers/Components.hs
@@ -270,18 +270,22 @@ spawnMonitor ConsumerConfig {..} cs cid = forkP "monitor" . forever $ do
             , "WHERE reserved_by = ANY(" <?> Array1 inactive <+> ")"
             , "FOR UPDATE SKIP LOCKED"
             ]
-        stuckJobs <- rights <$> fetchMany ccJobFetcher
+        stuckJobs <- fetchMany ccJobFetcher
         unless (null stuckJobs) $ do
           results <- forM stuckJobs $ \job -> do
-            action <- lift $ ccOnException (toException ThreadKilled) job
-            pure (ccJobIndex job, Failed action)
+            action <- lift $ 
+              either 
+                (\(idx, t) -> ccOnFailedToFetchJob t idx) 
+                (ccOnException (toException ThreadKilled))
+                job
+            pure (either fst ccJobIndex job, Failed action)
           runSQL_ $ updateJobsQuery ccJobsTable results now
         runPreparedSQL_ (preparedSqlName "removeInactive" ccConsumersTable) $
           smconcat
             [ "DELETE FROM" <+> raw ccConsumersTable
             , "WHERE id = ANY(" <?> Array1 inactive <+> ")"
             ]
-        pure (length inactive, map ccJobIndex stuckJobs)
+        pure (length inactive, fmap (either fst ccJobIndex) stuckJobs)
   when (inactiveConsumers > 0) $ do
     logInfo "Unregistered inactive consumers" $
       object
@@ -361,7 +365,7 @@ spawnDispatcher ConsumerConfig {..} cs cid semaphore runningJobsInfo runningJobs
 
       pure (batchSize > 0)
 
-    reserveJobs :: MonadCatch m => Int -> m ([Either (idx, T.Text) job], Int)
+    reserveJobs :: Int -> m ([Either (idx, T.Text) job], Int)
     reserveJobs limit = runDBT cs ts $ do
       now <- currentTime
       n <-
@@ -376,6 +380,7 @@ spawnDispatcher ConsumerConfig {..} cs cid semaphore runningJobsInfo runningJobs
             , "WHERE id IN (" <> reservedJobs now <> ")"
             , "RETURNING" <+> mintercalate ", " ccJobSelectors
             ]
+      -- Decode lazily as we want the transaction to be as short as possible
       (,n) . F.toList . fmap ccJobFetcher <$> queryResult
       where
         reservedJobs :: UTCTime -> SQL

--- a/consumers/src/Database/PostgreSQL/Consumers/Components.hs
+++ b/consumers/src/Database/PostgreSQL/Consumers/Components.hs
@@ -10,7 +10,7 @@ import Control.Concurrent.Lifted
 import Control.Concurrent.STM hiding (atomically)
 import Control.Concurrent.STM qualified as STM
 import Control.Concurrent.Thread.Lifted qualified as T
-import Control.Exception (AsyncException (ThreadKilled))
+import Control.Exception (AsyncException (ThreadKilled), evaluate)
 import Control.Exception.Safe qualified as ES
 import Control.Monad
 import Control.Monad.Base
@@ -375,9 +375,11 @@ spawnDispatcher ConsumerConfig {..} cs cid semaphore runningJobsInfo runningJobs
             , "WHERE id IN (" <> reservedJobs now <> ")"
             , "RETURNING" <+> mintercalate ", " ccJobSelectors
             ]
-      let tryAndParse :: (row -> job) -> row -> Either row job
-          tryAndParse p row = ES.handle (\(SomeException _) -> Left row) (Right $ p row)
-      (,n) . F.toList . fmap (tryAndParse ccJobFetcher) <$> queryResult
+      let tryAndParse row = ES.handle
+            (\(SomeException _) -> pure $ Left row)
+            (fmap Right . liftBase . evaluate $ ccJobFetcher row)
+      _ {- ([row], [job]) -} <- fmap partitionEithers . traverse tryAndParse . F.toList =<< queryResult
+      undefined
       where
         reservedJobs :: UTCTime -> SQL
         reservedJobs now =

--- a/consumers/src/Database/PostgreSQL/Consumers/Config.hs
+++ b/consumers/src/Database/PostgreSQL/Consumers/Config.hs
@@ -110,6 +110,12 @@ data ConsumerConfig m idx job = forall row. FromRow row => ConsumerConfig
   -- ^ Function that processes a job. It's recommended to process each job in a
   -- separate DB transaction, otherwise you'll have to remember to commit your
   -- changes to the database manually.
+  , ccRowIndex :: !(row -> idx)
+  , ccOnFailedToFetchJob :: !(row -> m Result)
+  -- ^ Action taken if fetching a job failed. It is advised to reenqueue the
+  -- job at a later date and emit a warning in such a case. This is mostly
+  -- to ensure the application using consumers won't fail completely when
+  -- this happens.
   , ccOnException :: !(SomeException -> job -> m Action)
   -- ^ Action taken if a job processing function throws an exception. For
   -- robustness it's best to ensure that it doesn't throw. If it does, the

--- a/consumers/src/Database/PostgreSQL/Consumers/Config.hs
+++ b/consumers/src/Database/PostgreSQL/Consumers/Config.hs
@@ -7,6 +7,7 @@ module Database.PostgreSQL.Consumers.Config
 
 import Control.Exception (SomeException)
 import Data.Aeson.Types qualified as A
+import Data.Text
 import Data.Time
 import Database.PostgreSQL.PQTypes.FromRow
 import Database.PostgreSQL.PQTypes.Interval
@@ -14,7 +15,6 @@ import Database.PostgreSQL.PQTypes.Notification
 import Database.PostgreSQL.PQTypes.SQL
 import Database.PostgreSQL.PQTypes.SQL.Raw
 import Log
-import Data.Text
 
 -- | Action to take after a job was processed.
 data Action

--- a/consumers/src/Database/PostgreSQL/Consumers/Config.hs
+++ b/consumers/src/Database/PostgreSQL/Consumers/Config.hs
@@ -132,5 +132,5 @@ data ConsumerConfig m idx job = forall row. FromRow row => ConsumerConfig
 -- This will create a logAttention and reenqueue, to be replayed in one day.
 defaultOnFailedToFetchJob :: (MonadLog m, Show idx) => Text -> idx -> m Action
 defaultOnFailedToFetchJob msg idx = do
-  logAttention "Unexpected unparseable job" $ A.object ["error" A..= msg, "job_id" A..= show idx]
+  logAttention "Unexpected unparseable job" $ A.object ["error" A..= msg, "consumers_job_id" A..= show idx]
   pure . RerunAfter $ idays 1

--- a/consumers/src/Database/PostgreSQL/Consumers/Config.hs
+++ b/consumers/src/Database/PostgreSQL/Consumers/Config.hs
@@ -2,7 +2,7 @@ module Database.PostgreSQL.Consumers.Config
   ( Action (..)
   , Result (..)
   , ConsumerConfig (..)
-  , shouldNotFail
+  , defaultOnFailedToFetchJob
   ) where
 
 import Control.Exception (SomeException)
@@ -14,6 +14,7 @@ import Database.PostgreSQL.PQTypes.Notification
 import Database.PostgreSQL.PQTypes.SQL
 import Database.PostgreSQL.PQTypes.SQL.Raw
 import Log
+import Data.Text
 
 -- | Action to take after a job was processed.
 data Action
@@ -80,7 +81,7 @@ data ConsumerConfig m idx job = forall row. FromRow row => ConsumerConfig
   , ccJobSelectors :: ![SQL]
   -- ^ Fields needed to be selected from the jobs table in order to assemble a
   -- job.
-  , ccJobFetcher :: !(row -> Either (idx, String) job)
+  , ccJobFetcher :: !(row -> Either (idx, Text) job)
   -- ^ Function that transforms the list of fields into a job.
   , ccJobIndex :: !(job -> idx)
   -- ^ Selector for taking out job ID from the job object.
@@ -112,7 +113,7 @@ data ConsumerConfig m idx job = forall row. FromRow row => ConsumerConfig
   -- ^ Function that processes a job. It's recommended to process each job in a
   -- separate DB transaction, otherwise you'll have to remember to commit your
   -- changes to the database manually.
-  , ccOnFailedToFetchJob :: !(String -> idx -> m Action)
+  , ccOnFailedToFetchJob :: !(Text -> idx -> m Action)
   -- ^ Action taken if fetching a job failed. It is advised to reenqueue the
   -- job at a later date and emit a warning in such a case. This is mostly
   -- to ensure the application using consumers won't fail completely when
@@ -128,7 +129,7 @@ data ConsumerConfig m idx job = forall row. FromRow row => ConsumerConfig
 -- | A default implementation for ccOnFailedToFetchJob,
 -- when the parsing of the row should never fail.
 -- This will create a logAttention and reenqueue for the next day.
-shouldNotFail :: MonadLog m => String -> idx -> m Action
-shouldNotFail msg _ = do
-  logAttention "Unexpected unparseable job" $ A.object ["error" A..= msg]
+defaultOnFailedToFetchJob :: (MonadLog m, Show idx) => Text -> idx -> m Action
+defaultOnFailedToFetchJob msg idx = do
+  logAttention "Unexpected unparseable job" $ A.object ["error" A..= msg, "idx" A..= show idx]
   pure . RerunAfter $ idays 48

--- a/consumers/src/Database/PostgreSQL/Consumers/Config.hs
+++ b/consumers/src/Database/PostgreSQL/Consumers/Config.hs
@@ -2,6 +2,7 @@ module Database.PostgreSQL.Consumers.Config
   ( Action (..)
   , Result (..)
   , ConsumerConfig (..)
+  , shouldNotFail
   ) where
 
 import Control.Exception (SomeException)
@@ -12,6 +13,7 @@ import Database.PostgreSQL.PQTypes.Interval
 import Database.PostgreSQL.PQTypes.Notification
 import Database.PostgreSQL.PQTypes.SQL
 import Database.PostgreSQL.PQTypes.SQL.Raw
+import Log
 
 -- | Action to take after a job was processed.
 data Action
@@ -122,3 +124,11 @@ data ConsumerConfig m idx job = forall row. FromRow row => ConsumerConfig
   , ccJobLogData :: !(job -> [A.Pair])
   -- ^ Data to attach to each log message while processing a job.
   }
+
+-- | A default implementation for ccOnFailedToFetchJob,
+-- when the parsing of the row should never fail.
+-- This will create a logAttention and reenqueue for the next day.
+shouldNotFail :: MonadLog m => String -> idx -> m Action
+shouldNotFail msg _ = do
+  logAttention "Unexpected unparseable job" $ A.object ["error" A..= msg]
+  pure . RerunAfter $ idays 48

--- a/consumers/src/Database/PostgreSQL/Consumers/Config.hs
+++ b/consumers/src/Database/PostgreSQL/Consumers/Config.hs
@@ -78,7 +78,7 @@ data ConsumerConfig m idx job = forall row. FromRow row => ConsumerConfig
   , ccJobSelectors :: ![SQL]
   -- ^ Fields needed to be selected from the jobs table in order to assemble a
   -- job.
-  , ccJobFetcher :: !(row -> job)
+  , ccJobFetcher :: !(row -> Either (idx, String) job)
   -- ^ Function that transforms the list of fields into a job.
   , ccJobIndex :: !(job -> idx)
   -- ^ Selector for taking out job ID from the job object.
@@ -110,8 +110,7 @@ data ConsumerConfig m idx job = forall row. FromRow row => ConsumerConfig
   -- ^ Function that processes a job. It's recommended to process each job in a
   -- separate DB transaction, otherwise you'll have to remember to commit your
   -- changes to the database manually.
-  , ccRowIndex :: !(row -> idx)
-  , ccOnFailedToFetchJob :: !(row -> m Result)
+  , ccOnFailedToFetchJob :: !(String -> idx -> m Action)
   -- ^ Action taken if fetching a job failed. It is advised to reenqueue the
   -- job at a later date and emit a warning in such a case. This is mostly
   -- to ensure the application using consumers won't fail completely when

--- a/consumers/src/Database/PostgreSQL/Consumers/Config.hs
+++ b/consumers/src/Database/PostgreSQL/Consumers/Config.hs
@@ -128,8 +128,8 @@ data ConsumerConfig m idx job = forall row. FromRow row => ConsumerConfig
 
 -- | A default implementation for ccOnFailedToFetchJob,
 -- when the parsing of the row should never fail.
--- This will create a logAttention and reenqueue for the next day.
+-- This will create a logAttention and reenqueue, to be replayed in 2 days.
 defaultOnFailedToFetchJob :: (MonadLog m, Show idx) => Text -> idx -> m Action
 defaultOnFailedToFetchJob msg idx = do
   logAttention "Unexpected unparseable job" $ A.object ["error" A..= msg, "idx" A..= show idx]
-  pure . RerunAfter $ idays 48
+  pure . RerunAfter $ ihours 48

--- a/consumers/src/Database/PostgreSQL/Consumers/Config.hs
+++ b/consumers/src/Database/PostgreSQL/Consumers/Config.hs
@@ -7,7 +7,7 @@ module Database.PostgreSQL.Consumers.Config
 
 import Control.Exception (SomeException)
 import Data.Aeson.Types qualified as A
-import Data.Text
+import Data.Text (Text)
 import Data.Time
 import Database.PostgreSQL.PQTypes.FromRow
 import Database.PostgreSQL.PQTypes.Interval
@@ -132,5 +132,5 @@ data ConsumerConfig m idx job = forall row. FromRow row => ConsumerConfig
 -- This will create a logAttention and reenqueue, to be replayed in 2 days.
 defaultOnFailedToFetchJob :: (MonadLog m, Show idx) => Text -> idx -> m Action
 defaultOnFailedToFetchJob msg idx = do
-  logAttention "Unexpected unparseable job" $ A.object ["error" A..= msg, "idx" A..= show idx]
-  pure . RerunAfter $ ihours 48
+  logAttention "Unexpected unparseable job" $ A.object ["error" A..= msg, "job_id" A..= show idx]
+  pure . RerunAfter $ idays 1

--- a/consumers/src/Database/PostgreSQL/Consumers/Config.hs
+++ b/consumers/src/Database/PostgreSQL/Consumers/Config.hs
@@ -129,7 +129,7 @@ data ConsumerConfig m idx job = forall row. FromRow row => ConsumerConfig
 
 -- | A default implementation for ccOnFailedToFetchJob,
 -- when the parsing of the row should never fail.
--- This will create a logAttention and reenqueue, to be replayed in 2 days.
+-- This will create a logAttention and reenqueue, to be replayed in one day.
 defaultOnFailedToFetchJob :: (MonadLog m, Show idx) => Text -> idx -> m Action
 defaultOnFailedToFetchJob msg idx = do
   logAttention "Unexpected unparseable job" $ A.object ["error" A..= msg, "job_id" A..= show idx]

--- a/consumers/src/Database/PostgreSQL/Consumers/Config.hs
+++ b/consumers/src/Database/PostgreSQL/Consumers/Config.hs
@@ -117,7 +117,8 @@ data ConsumerConfig m idx job = forall row. FromRow row => ConsumerConfig
   -- ^ Action taken if fetching a job failed. It is advised to reenqueue the
   -- job at a later date and emit a warning in such a case. This is mostly
   -- to ensure the application using consumers won't fail completely when
-  -- this happens.
+  -- this happens. See 'defaultOnFailedToFetchJob' for a simple implementation
+  -- which logs and reenqueue.
   , ccOnException :: !(SomeException -> job -> m Action)
   -- ^ Action taken if a job processing function throws an exception. For
   -- robustness it's best to ensure that it doesn't throw. If it does, the

--- a/consumers/test/Test.hs
+++ b/consumers/test/Test.hs
@@ -145,11 +145,12 @@ test = do
         { ccJobsTable = "consumers_test_jobs"
         , ccConsumersTable = "consumers_test_consumers"
         , ccJobSelectors = ["id", "countdown"]
-        , ccJobFetcher = id
+        , ccJobFetcher = Right
         , ccJobIndex = \(i :: Int64, _ :: Int32) -> i
         , ccNotificationChannel = Just "consumers_test_chan"
         , -- select some small timeout
           ccNotificationTimeout = 100 * 1000 -- 100 msec
+        , ccOnFailedToFetchJob = \_ _ -> pure . RerunAfter $ idays 14
         , ccMaxRunningJobs = 20
         , ccProcessJob = processJob
         , ccOnException = handleException

--- a/consumers/test/Test.hs
+++ b/consumers/test/Test.hs
@@ -150,7 +150,7 @@ test = do
         , ccNotificationChannel = Just "consumers_test_chan"
         , -- select some small timeout
           ccNotificationTimeout = 100 * 1000 -- 100 msec
-        , ccOnFailedToFetchJob = \_ _ -> pure . RerunAfter $ idays 14
+        , ccOnFailedToFetchJob = defaultOnFailedToFetchJob
         , ccMaxRunningJobs = 20
         , ccProcessJob = processJob
         , ccOnException = handleException


### PR DESCRIPTION
Proposal to ensure that an application running several different consumers doesn't crash if one of the job is unparseable for some reason.

I didn't find a way to plug this to `consumer-monitoring`, unfortunately. I guess warning on a high number of failure in `consumers_job_execution_seconds`, which despite the misleading name, includes the job_result is still the best way to go to detect this kind of issues. Or perhaps this is a good case for using `logAttention`.