### PR TITLE
Fix exception handling when fetching jobs

### DIFF
--- a/consumers/src/Database/PostgreSQL/Consumers/Components.hs
+++ b/consumers/src/Database/PostgreSQL/Consumers/Components.hs
@@ -377,13 +377,13 @@ spawnDispatcher ConsumerConfig {..} cs cid semaphore runningJobsInfo runningJobs
       jobIds :: [idx] <- fetchMany runIdentity
       if null jobIds
         then pure []
-        else
+        else do
           handle
             ( \(DBException _ _ e _) -> do
                 logAttention "Failure to fetch the jobs, will reenqueue for the next day" $ object ["error" .= show e, "job_ids" .= show jobIds]
                 rollback
                 lift $ fetchFailureHandler jobIds
-                pure []
+                pure ()
             )
             ( do
                 runPreparedSQL_ (preparedSqlName "setReservation" ccJobsTable) $
@@ -397,16 +397,16 @@ spawnDispatcher ConsumerConfig {..} cs cid semaphore runningJobsInfo runningJobs
                     , "WHERE id = ANY(" <?> Array1 jobIds <+> ")"
                     , "RETURNING id, " <+> mintercalate ", " ccJobSelectors
                     ]
-                qr <- queryResult
-                results <- forM (F.toList qr) $ \(rawJobId :*: other) -> do
-                  let jobId = runIdentity rawJobId
-                  (Just <$> liftBase (evaluate $ ccJobFetcher other)) `catch` \(DBException _ _ e _) -> do
-                    logAttention "Failure to fetch job, will reenqueue for the next day" $ object ["error" .= show e, "job_id" .= show jobId]
-                    rollback
-                    lift $ fetchFailureHandler [jobId]
-                    pure Nothing
-                pure $ catMaybes results
             )
+          qr <- queryResult
+          results <- forM (F.toList qr) $ \(rawJobId :*: other) -> do
+            let jobId = runIdentity rawJobId
+            (Just <$> liftBase (evaluate $ ccJobFetcher other)) `catch` \(DBException _ _ e _) -> do
+              logAttention "Failure to fetch job, will reenqueue for the next day" $ object ["error" .= show e, "job_id" .= show jobId]
+              rollback
+              lift $ fetchFailureHandler [jobId]
+              pure Nothing
+          pure $ catMaybes results
 
     fetchFailureHandler :: [idx] -> m ()
     fetchFailureHandler jobIds = do

--- a/consumers/src/Database/PostgreSQL/Consumers/Components.hs
+++ b/consumers/src/Database/PostgreSQL/Consumers/Components.hs
@@ -379,7 +379,7 @@ spawnDispatcher ConsumerConfig {..} cs cid semaphore runningJobsInfo runningJobs
         then pure []
         else
           handle
-            ( \(SomeException e) -> do
+            ( \(DBException _ _ e _) -> do
                 logAttention "Failure to fetch the jobs, will reenqueue for the next day" $ object ["error" .= show e, "job_ids" .= show jobIds]
                 rollback
                 lift $ fetchFailureHandler jobIds
@@ -400,7 +400,7 @@ spawnDispatcher ConsumerConfig {..} cs cid semaphore runningJobsInfo runningJobs
                 qr <- queryResult
                 results <- forM (F.toList qr) $ \(rawJobId :*: other) -> do
                   let jobId = runIdentity rawJobId
-                  (Just <$> liftBase (evaluate $ ccJobFetcher other)) `catch` \(SomeException e) -> do
+                  (Just <$> liftBase (evaluate $ ccJobFetcher other)) `catch` \(DBException _ _ e _) -> do
                     logAttention "Failure to fetch job, will reenqueue for the next day" $ object ["error" .= show e, "job_id" .= show jobId]
                     rollback
                     lift $ fetchFailureHandler [jobId]


### PR DESCRIPTION
- Ensure we only catch `DBException` when fetching jobs;
- Split the handling in two better separated blocks.