### PR TITLE
Unexpected exception should be a logAttention

### DIFF
--- a/consumers/src/Database/PostgreSQL/Consumers/Components.hs
+++ b/consumers/src/Database/PostgreSQL/Consumers/Components.hs
@@ -127,7 +127,7 @@ runConsumerWithMaybeIdleSignal cc0 cs mIdleSignal
         { ccOnException = \ex job -> localData (ccJobLogData cc0 job) $ do
             let doOnException = do
                   action <- ccOnException cc0 ex job
-                  logInfo "Unexpected exception caught while processing job" $
+                  logAttention "Unexpected exception caught while processing job" $
                     object
                       [ "exception" .= show ex
                       , "action" .= show action


### PR DESCRIPTION
As these are typically serious issues (and potentially something we want to have an alert on), a logInfo is probably too low for unexpected exception.